### PR TITLE
Add initial CSV parsers for PyCanZE

### DIFF
--- a/PyCanZE/pycanze/__init__.py
+++ b/PyCanZE/pycanze/__init__.py
@@ -1,0 +1,21 @@
+"""Python utilities for CanZE data.
+
+This package parses the CSV database copied
+from the original Android project.  It exposes dataclasses for ECUs,
+frames and fields as well as helper functions to load them from the
+CSV files in :mod:`pycanze.data`.
+"""
+
+from .models import Ecu, Frame, Field
+from .parser import load_ecus, load_frames, load_fields, load_database
+
+__all__ = [
+    "Ecu",
+    "Frame",
+    "Field",
+    "load_ecus",
+    "load_frames",
+    "load_fields",
+    "load_database",
+]
+

--- a/PyCanZE/pycanze/models.py
+++ b/PyCanZE/pycanze/models.py
@@ -1,0 +1,50 @@
+"""Dataclasses representing CanZE metadata."""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+
+@dataclass(frozen=True)
+class Ecu:
+    """Electronic Control Unit description."""
+
+    name: str
+    sid: int
+    networks: List[str]
+    request_id: int
+    response_id: int
+    mnemonic: str
+    aliases: List[str]
+    dtc_response_ids: List[int]
+    start_diag: Optional[int]
+    session_required: int
+
+
+@dataclass(frozen=True)
+class Frame:
+    """CAN frame description."""
+
+    frame_id: int
+    interval_zoe: int
+    interval_flukan: int
+    ecu: str
+
+
+@dataclass(frozen=True)
+class Field:
+    """Field description within a frame."""
+
+    sid: str
+    frame_id: int
+    start_bit: int
+    end_bit: int
+    resolution: float
+    offset: float
+    decimals: int
+    unit: str
+    request_id: Optional[int]
+    response_id: Optional[int]
+    options: List[str] = field(default_factory=list)
+    name: Optional[str] = None
+    raw_values: Optional[str] = None
+

--- a/PyCanZE/pycanze/parser.py
+++ b/PyCanZE/pycanze/parser.py
@@ -1,0 +1,175 @@
+"""Parsers for the CSV database files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Iterable, Iterator, List, Tuple
+
+from .models import Ecu, Frame, Field
+
+DATA_DIR = Path(__file__).resolve().parent / "data"
+
+
+def _read_csv(path: Path) -> Iterator[List[str]]:
+    """Yield rows from *path* with comments stripped."""
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.split("#", 1)[0].strip()
+            if not line:
+                continue
+            yield [col.strip() for col in line.split(",")]
+
+
+def _auto_int(value: str) -> int:
+    """Return *value* parsed as int accepting hex or decimal."""
+    value = value.strip()
+    if not value:
+        return 0
+    try:
+        return int(value, 0)
+    except ValueError:
+        return int(value, 16)
+
+
+def load_ecus(base_dir: Path = DATA_DIR) -> Dict[int, Ecu]:
+    """Parse all ``_Ecus.csv`` files found in *base_dir*.
+
+    Returns a mapping of SID to :class:`Ecu`.
+    """
+
+    ecus: Dict[int, Ecu] = {}
+    for vehicle_dir in base_dir.iterdir():
+        csv_file = vehicle_dir / "_Ecus.csv"
+        if not csv_file.exists():
+            continue
+        for row in _read_csv(csv_file):
+            name = row[0]
+            sid = int(row[1])
+            networks = row[2].split(";") if len(row) > 2 and row[2] else []
+            request_id = _auto_int(row[3])
+            response_id = _auto_int(row[4])
+            mnemonic = row[5]
+            aliases = row[6].split(";") if len(row) > 6 and row[6] else []
+            dtc_response_ids = [
+                _auto_int(x) for x in row[7].split(";") if x
+            ] if len(row) > 7 else []
+            start_diag = _auto_int(row[8]) if len(row) > 8 and row[8] else None
+            session_required = int(row[9]) if len(row) > 9 and row[9] else 0
+            ecus[sid] = Ecu(
+                name=name,
+                sid=sid,
+                networks=networks,
+                request_id=request_id,
+                response_id=response_id,
+                mnemonic=mnemonic,
+                aliases=aliases,
+                dtc_response_ids=dtc_response_ids,
+                start_diag=start_diag,
+                session_required=session_required,
+            )
+    return ecus
+
+
+def load_frames(base_dir: Path = DATA_DIR) -> Dict[int, Frame]:
+    """Parse ``_Frames.csv`` files and return a mapping by frame id."""
+
+    frames: Dict[int, Frame] = {}
+    for vehicle_dir in base_dir.iterdir():
+        csv_file = vehicle_dir / "_Frames.csv"
+        if not csv_file.exists():
+            continue
+        for row in _read_csv(csv_file):
+            frame_id = _auto_int(row[0])
+            interval_zoe = int(row[1])
+            interval_flukan = int(row[2])
+            ecu = row[3]
+            frames[frame_id] = Frame(
+                frame_id=frame_id,
+                interval_zoe=interval_zoe,
+                interval_flukan=interval_flukan,
+                ecu=ecu,
+            )
+    return frames
+
+
+def load_fields(base_dir: Path = DATA_DIR) -> Tuple[Dict[str, Field], Dict[str, Field]]:
+    """Parse ``*_Fields.csv`` files.
+
+    Returns two dictionaries: by SID and by field name.
+    """
+
+    by_sid: Dict[str, Field] = {}
+    by_name: Dict[str, Field] = {}
+
+    for vehicle_dir in base_dir.iterdir():
+        for csv_file in vehicle_dir.glob("*_Fields.csv"):
+            for row in _read_csv(csv_file):
+                row += [""] * (13 - len(row))
+                (
+                    sid,
+                    frame_id_s,
+                    start_bit_s,
+                    end_bit_s,
+                    resolution_s,
+                    offset_s,
+                    decimals_s,
+                    unit,
+                    request_id_s,
+                    response_id_s,
+                    options_s,
+                    name,
+                    raw_values,
+                ) = row[:13]
+
+                frame_id = _auto_int(frame_id_s) if frame_id_s else 0
+                start_bit = int(start_bit_s)
+                end_bit = int(end_bit_s)
+                resolution = float(resolution_s) if resolution_s else 1.0
+                offset = float(offset_s) if offset_s else 0.0
+                decimals = int(decimals_s) if decimals_s else 0
+                try:
+                    request_id = _auto_int(request_id_s) if request_id_s else None
+                except ValueError:
+                    request_id = None
+                try:
+                    response_id = _auto_int(response_id_s) if response_id_s else None
+                except ValueError:
+                    response_id = None
+                options = [options_s[i : i + 2] for i in range(0, len(options_s), 2)] if options_s else []
+                sid = sid or f"{frame_id_s}.{start_bit_s}.{response_id_s}"
+
+                field = Field(
+                    sid=sid,
+                    frame_id=frame_id,
+                    start_bit=start_bit,
+                    end_bit=end_bit,
+                    resolution=resolution,
+                    offset=offset,
+                    decimals=decimals,
+                    unit=unit,
+                    request_id=request_id,
+                    response_id=response_id,
+                    options=options,
+                    name=name or None,
+                    raw_values=raw_values or None,
+                )
+                by_sid[sid] = field
+                if field.name:
+                    by_name[field.name] = field
+
+    return by_sid, by_name
+
+
+def load_database(base_dir: Path = DATA_DIR):
+    """Convenience loader returning all parsed structures."""
+
+    ecus = load_ecus(base_dir)
+    frames = load_frames(base_dir)
+    fields_by_sid, fields_by_name = load_fields(base_dir)
+    return {
+        "ecus": ecus,
+        "frames": frames,
+        "fields_by_sid": fields_by_sid,
+        "fields_by_name": fields_by_name,
+    }
+


### PR DESCRIPTION
## Summary
- add dataclasses for ECUs, frames and fields with optional integer IDs
- implement CSV parsers with comment stripping and flexible number parsing
- provide lookup utilities for SIDs and field names

## Testing
- `PYTHONPATH=PyCanZE python - <<'PY'
from pycanze import load_database
DB = load_database()
print('ECUs', len(DB['ecus']))
print('Frames', len(DB['frames']))
print('Fields', len(DB['fields_by_sid']))
first_field = next(iter(DB['fields_by_sid'].values()))
print('Sample field request_id:', first_field.request_id)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b09f3bd38c83309b487a104ae26711