### PR TITLE
Add battery health sweep harness

### DIFF
--- a/PyCanZE/Testing/README.md
+++ b/PyCanZE/Testing/README.md
@@ -1,0 +1,36 @@
+# Testing utilities
+
+This directory contains experimental utilities for validating CanZE's Python
+UDS client.
+
+## `sweep_battery_health.sh`
+
+`sweep_battery_health.sh` runs `tools/battery_health.py` across a matrix of
+ELM327 and ISO-TP timing parameters. Each combination is logged under
+`logs/battery_sweep_<timestamp>/`.
+
+### Usage
+
+```bash
+./sweep_battery_health.sh [host] [port] [car]
+```
+
+- `host` – ELM327 IP (default: `192.168.2.21`)
+- `port` – ELM327 TCP port (default: `35000`)
+- `car` – vehicle asset folder (default: `ZOE`)
+
+### Parameters swept
+
+The script iterates over:
+
+- **CAF**: `ATCAF0` and `ATCAF1`
+- **Mask filter usage**: `ATCRA` vs `ATCF`/`ATCM`
+- **Flow control STmin**: `0` and `5` ms
+- **Header settle delay**: `0` and `100` ms
+- **First 0x21 delay**: `0` and `150` ms per ECU
+- **LBC first 0x21 delay**: `0` and `150` ms
+- **ATST timeout**: `0` and `40` ms
+- **ISO‑TP collect window**: `0.5` s and `1.0` s
+- **Consecutive‑frame read timeout**: `0.1` s and `0.3` s
+
+Each run produces a log file named after the parameter values.

--- a/PyCanZE/Testing/sweep_battery_health.sh
+++ b/PyCanZE/Testing/sweep_battery_health.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Sweep battery_health.py across timing and filter parameters
+# Logs are stored under Testing/logs/battery_sweep_<timestamp>/
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+LOG_ROOT="$ROOT_DIR/Testing/logs"
+TS="$(date +%Y%m%d_%H%M%S)"
+OUT_DIR="$LOG_ROOT/battery_sweep_${TS}"
+mkdir -p "$OUT_DIR"
+
+HOST=${1:-192.168.2.21}
+PORT=${2:-35000}
+CAR=${3:-ZOE}
+
+CAF_VALUES=(0 1)
+MASK_VALUES=(0 1) # 0 -> ATCRA, 1 -> ATCF/ATCM
+STMIN_VALUES=(0 5)
+HEADER_SETTLE_MS_VALUES=(0 100)
+FIRST21_DELAY_MS_VALUES=(0 150)
+LBC_FIRST21_DELAY_MS_VALUES=(0 150)
+ATST_MS_VALUES=(0 40)
+ISOTP_COLLECT_S_VALUES=(0.5 1.0)
+CF_READ_TIMEOUT_S_VALUES=(0.1 0.3)
+
+for caf in "${CAF_VALUES[@]}"; do
+  for mask in "${MASK_VALUES[@]}"; do
+    for stmin in "${STMIN_VALUES[@]}"; do
+      for settle in "${HEADER_SETTLE_MS_VALUES[@]}"; do
+        for first21 in "${FIRST21_DELAY_MS_VALUES[@]}"; do
+          for lbc_first21 in "${LBC_FIRST21_DELAY_MS_VALUES[@]}"; do
+            for atst in "${ATST_MS_VALUES[@]}"; do
+              for collect in "${ISOTP_COLLECT_S_VALUES[@]}"; do
+                for cftime in "${CF_READ_TIMEOUT_S_VALUES[@]}"; do
+                  log_file="$OUT_DIR/caf${caf}_mask${mask}_stmin${stmin}_settle${settle}_first21${first21}_lbcfirst21${lbc_first21}_atst${atst}_collect${collect}_cftime${cftime}.log"
+                  cmd=(python3 "$ROOT_DIR/tools/battery_health.py" "$CAR" --host "$HOST" --port "$PORT" --caf "$caf" --stmin-ms "$stmin" --header-settle-ms "$settle" --first-21-delay-ms "$first21" --lbc-first-21-delay-ms "$lbc_first21" --atst-ms "$atst" --isotp-collect-s "$collect" --cf-read-timeout-s "$cftime")
+                  if [[ "$mask" -eq 1 ]]; then
+                    cmd+=(--use-mask-filter)
+                  fi
+                  "${cmd[@]}" >"$log_file" 2>&1 || true
+                done
+              done
+            done
+          done
+        done
+      done
+    done
+  done
+ done
+
+echo "Logs written to $OUT_DIR"


### PR DESCRIPTION
## Summary
- add sweep_battery_health.sh to scan timing and filter options
- document testing utilities and sweep parameters

## Testing
- `bash -n PyCanZE/Testing/sweep_battery_health.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b2ac107a888330a9810a1f1f780dde