### PR TITLE
docs: document AT init and wide CF fallback

### DIFF
--- a/PyCanZE/AGENTS.md
+++ b/PyCanZE/AGENTS.md
@@ -78,3 +78,9 @@ Reference notes
 - **Tester-present cadence** – charging tech scheduling sends `BcbTesterAwake` every 1500 ms【F:app/src/main/java/lu/fisch/canze/activities/ChargingTechActivity.java†L80-L105】
 - **LBC addressing variants** – assets show request/response IDs: `7BB→79B` for legacy models【F:app/src/main/assets/ZOE/_Ecus.csv†L5】, `7BB→79B` on Twingo Ph2【F:app/src/main/assets/Twingo_3_Ph2/_Ecus.csv†L7】, and extended `18DAF1DB→18DADBF1` for ZOE Ph2【F:app/src/main/assets/ZOE_Ph2/_Ecus.csv†L18】
 - **Unused commands** – searches found no `ATCFC1`, `ATCF`, `ATCM`, or `ATST` usage (`rg -i atcfc1`, `atcf`, `atcm`, `atst`)【049216†L1-L2】【a0b7bc†L1-L2】【dcb514†L1-L2】【b87152†L1-L2】
+
+## AT port report (2025-02-14)
+
+- **AT init sequence** – `ATZ; ATE0; ATS0; ATH0; ATL0; ATAL; ATCAF{0|1}; ATFCSH77B; ATFCSD3000xx; ATFCSM1; ATSP6`
+- **Timing defaults** – header settle 0 ms; first‑0x21 delay 0 ms (configurable); TesterPresent every 1500 ms; ISO‑TP collect window 2.5 s with 1.2 s CF read timeout.
+- **Python differences** – optional wide‑CF fallback widens filters and enables `ATH1` when CFs are missing; flow control retry reasserts `ATCFC1`/`ATFCSD` before one retry; environment knobs (`PYCANZE_*`) expose the above timings.

--- a/PyCanZE/README.md
+++ b/PyCanZE/README.md
@@ -8,14 +8,18 @@ from CanZE to communicate with the car via an ELM327-compatible interface.
 ## Contents
 
 * `pycanze/` – library with parsers and a minimal UDS client
-* `tools/` – command-line utilities such as `scan_car.py`
-* `Testing/` – experimental scripts and prototypes
+* `tools/` – command-line utilities such as `scan_car.py` and
+  `battery_health.py`
+* `Testing/` – experimental scripts and prototypes including sweep harnesses
 
 ## Goals
 
 The immediate aim is to poll selected diagnostic registers and publish the
 decoded values over systems like MQTT. In the longer term a GUI similar to the
-original CanZE app may be created.
+original CanZE app may be created. The Python UDS client mirrors the Android
+app's AT initialisation sequence and offers tuning knobs for flow-control and
+timing. An optional *wide CF fallback* widens receive filters and enables
+``ATH1`` when LBC 0x21 pages miss consecutive frames.
 
 ## Usage
 
@@ -24,7 +28,13 @@ address::
 
     python tools/scan_car.py ZOE
 
-Specify `--host` and `--port` if your dongle uses different settings.
+Specify `--host` and `--port` if your dongle uses different settings. For
+LBC/EVC snapshots run::
+
+    python tools/battery_health.py ZOE
+
+Use `--wide-cf-fallback` if your dongle occasionally drops ISO‑TP consecutive
+frames from the LBC.
 
 Contributions are welcome!
 

--- a/PyCanZE/Testing/sweep_battery_health.sh
+++ b/PyCanZE/Testing/sweep_battery_health.sh
@@ -23,6 +23,7 @@ LBC_FIRST21_DELAY_MS_VALUES=(0 150)
 ATST_MS_VALUES=(0 40)
 ISOTP_COLLECT_S_VALUES=(0.5 1.0)
 CF_READ_TIMEOUT_S_VALUES=(0.1 0.3)
+WIDE_CF_FALLBACK_VALUES=(0 1)
 
 for caf in "${CAF_VALUES[@]}"; do
   for mask in "${MASK_VALUES[@]}"; do
@@ -33,12 +34,17 @@ for caf in "${CAF_VALUES[@]}"; do
             for atst in "${ATST_MS_VALUES[@]}"; do
               for collect in "${ISOTP_COLLECT_S_VALUES[@]}"; do
                 for cftime in "${CF_READ_TIMEOUT_S_VALUES[@]}"; do
-                  log_file="$OUT_DIR/caf${caf}_mask${mask}_stmin${stmin}_settle${settle}_first21${first21}_lbcfirst21${lbc_first21}_atst${atst}_collect${collect}_cftime${cftime}.log"
-                  cmd=(python3 "$ROOT_DIR/tools/battery_health.py" "$CAR" --host "$HOST" --port "$PORT" --caf "$caf" --stmin-ms "$stmin" --header-settle-ms "$settle" --first-21-delay-ms "$first21" --lbc-first-21-delay-ms "$lbc_first21" --atst-ms "$atst" --isotp-collect-s "$collect" --cf-read-timeout-s "$cftime")
-                  if [[ "$mask" -eq 1 ]]; then
-                    cmd+=(--use-mask-filter)
-                  fi
-                  "${cmd[@]}" >"$log_file" 2>&1 || true
+                  for wide in "${WIDE_CF_FALLBACK_VALUES[@]}"; do
+                    log_file="$OUT_DIR/caf${caf}_mask${mask}_stmin${stmin}_settle${settle}_first21${first21}_lbcfirst21${lbc_first21}_atst${atst}_collect${collect}_cftime${cftime}_wide${wide}.log"
+                    cmd=(python3 "$ROOT_DIR/tools/battery_health.py" "$CAR" --host "$HOST" --port "$PORT" --caf "$caf" --stmin-ms "$stmin" --header-settle-ms "$settle" --first-21-delay-ms "$first21" --lbc-first-21-delay-ms "$lbc_first21" --atst-ms "$atst" --isotp-collect-s "$collect" --cf-read-timeout-s "$cftime")
+                    if [[ "$mask" -eq 1 ]]; then
+                      cmd+=(--use-mask-filter)
+                    fi
+                    if [[ "$wide" -eq 1 ]]; then
+                      cmd+=(--wide-cf-fallback)
+                    fi
+                    "${cmd[@]}" >"$log_file" 2>&1 || true
+                  done
                 done
               done
             done

--- a/PyCanZE/tools/battery_health.py
+++ b/PyCanZE/tools/battery_health.py
@@ -11,6 +11,10 @@ Outputs a compact set of metrics helpful for monitoring battery health:
 - Balancing flags summary (LBC 21_07)
 
 Requires the same WiFi ELM327 setup used by other tools.
+
+The tool mirrors the app's AT sequence and exposes tunables for timing and
+filter behaviour. For LBC clones that occasionally lose consecutive frames a
+``--wide-cf-fallback`` option widens filters and enables ``ATH1`` temporarily.
 """
 from __future__ import annotations
 
@@ -38,20 +42,46 @@ def parse_args() -> argparse.Namespace:
         help="Attempt a diagnostic session on LBC before 0x21 reads",
     )
     p.add_argument("--caf", type=int, choices=[0, 1], help="ATCAF mode (0/1)")
-    p.add_argument("--stmin-ms", type=int, help="Flow Control STmin in ms (ATFCSD 3000xx)")
-    p.add_argument("--header-settle-ms", type=float, help="Delay after ATSH/ATCRA before first request")
-    p.add_argument("--first-21-delay-ms", type=float, help="Delay before first 0x21 after header switch")
-    p.add_argument("--use-mask-filter", action="store_true", help="Use ATCF/ATCM instead of ATCRA")
+    p.add_argument(
+        "--stmin-ms", type=int, help="Flow Control STmin in ms (ATFCSD 3000xx)"
+    )
+    p.add_argument(
+        "--header-settle-ms",
+        type=float,
+        help="Delay after ATSH/ATCRA before first request",
+    )
+    p.add_argument(
+        "--first-21-delay-ms",
+        type=float,
+        help="Delay before first 0x21 after header switch",
+    )
+    p.add_argument(
+        "--use-mask-filter", action="store_true", help="Use ATCF/ATCM instead of ATCRA"
+    )
     p.add_argument(
         "--wide-cf-fallback",
         action="store_true",
         help="Temporarily widen filters and enable ATH1 if CFs are missing",
     )
-    p.add_argument("--atst-ms", type=float, help="ELM ATST timeout in ms (rounded to 4ms units)")
-    p.add_argument("--atst-hex", type=str, help="ELM ATST raw hex byte (overrides --atst-ms)")
-    p.add_argument("--isotp-collect-s", type=float, help="ISO-TP total collect window in seconds")
-    p.add_argument("--cf-read-timeout-s", type=float, help="Per-read timeout when collecting Consecutive Frames")
-    p.add_argument("--lbc-first-21-delay-ms", type=float, help="Override first-0x21 delay for LBC only")
+    p.add_argument(
+        "--atst-ms", type=float, help="ELM ATST timeout in ms (rounded to 4ms units)"
+    )
+    p.add_argument(
+        "--atst-hex", type=str, help="ELM ATST raw hex byte (overrides --atst-ms)"
+    )
+    p.add_argument(
+        "--isotp-collect-s", type=float, help="ISO-TP total collect window in seconds"
+    )
+    p.add_argument(
+        "--cf-read-timeout-s",
+        type=float,
+        help="Per-read timeout when collecting Consecutive Frames",
+    )
+    p.add_argument(
+        "--lbc-first-21-delay-ms",
+        type=float,
+        help="Override first-0x21 delay for LBC only",
+    )
     return p.parse_args()
 
 
@@ -68,6 +98,7 @@ def main() -> None:
         try:
             # Apply tunables via environment so uds.py can read them lazily
             import os
+
             if args.caf is not None:
                 os.environ["PYCANZE_CAF"] = str(args.caf)
             if args.stmin_ms is not None:
@@ -89,7 +120,9 @@ def main() -> None:
             if args.cf_read_timeout_s is not None:
                 os.environ["PYCANZE_CF_READ_TIMEOUT_S"] = str(args.cf_read_timeout_s)
             if args.lbc_first_21_delay_ms is not None:
-                os.environ["PYCANZE_FIRST_21_DELAY_LBC_MS"] = str(args.lbc_first_21_delay_ms)
+                os.environ["PYCANZE_FIRST_21_DELAY_LBC_MS"] = str(
+                    args.lbc_first_21_delay_ms
+                )
             client.initialize()
         except Exception as e:
             print(f"ELM327 initialization failed -> {e}")
@@ -131,7 +164,11 @@ def main() -> None:
                     nm_low_cmp = nm_low.split(") ", 1)[1]
                 else:
                     nm_low_cmp = nm_low
-                if nm_low_cmp == needle or nm_low.endswith(needle) or needle in nm_low_cmp:
+                if (
+                    nm_low_cmp == needle
+                    or nm_low.endswith(needle)
+                    or needle in nm_low_cmp
+                ):
                     return fld
                 # Normalize out spaces and punctuation to catch variants
                 if _normalize(nm_low_cmp) == needle_norm:
@@ -153,7 +190,9 @@ def main() -> None:
                     time.sleep(0.15)
                     v = client.read_field(f.sid)
                 if args.debug:
-                    print(f"[battery_health] -> {v} (status={getattr(client, 'last_status', None)})")
+                    print(
+                        f"[battery_health] -> {v} (status={getattr(client, 'last_status', None)})"
+                    )
                 return v
             except Exception:
                 return None
@@ -161,10 +200,17 @@ def main() -> None:
         # EVC basics
         soc = val("State Of Charge (SOC) HV battery")
         soh = val("State Of Health (SOH) HV battery")
-        hv_v = val("consolidated HV voltage") or val("($2004) consolidated HV voltage") or val("HV PEB voltage measure") or val("($3008) HV PEB voltage measure")
+        hv_v = (
+            val("consolidated HV voltage")
+            or val("($2004) consolidated HV voltage")
+            or val("HV PEB voltage measure")
+            or val("($3008) HV PEB voltage measure")
+        )
 
         # LBC 21_03 block
-        ocv = val("21_03#03 OCV (Open Circuit Voltage)") or val("21_03#03OCV(OpenCircuitVoltage)")
+        ocv = val("21_03#03 OCV (Open Circuit Voltage)") or val(
+            "21_03#03OCV(OpenCircuitVoltage)"
+        )
         v_max = (
             val("21_03_#13_Maximum_Cell_voltage")
             or val("21_03#13 Maximum Cell voltage")
@@ -180,14 +226,26 @@ def main() -> None:
         )
 
         # LBC 21_04 temps
-        t_avg = val("21_04_#76_Average_Battery_Temperature") or val("21_04#76 Average Battery Temperature")
-        t_min = val("21_04_#75_Minimum_Battery_Temperature") or val("21_04#75 Minimum Battery Temperature")
-        t_max = val("21_04_#77 Maximum Battery Temperature") or val("21_04#77 Maximum Battery Temperature")
+        t_avg = val("21_04_#76_Average_Battery_Temperature") or val(
+            "21_04#76 Average Battery Temperature"
+        )
+        t_min = val("21_04_#75_Minimum_Battery_Temperature") or val(
+            "21_04#75 Minimum Battery Temperature"
+        )
+        t_max = val("21_04_#77 Maximum Battery Temperature") or val(
+            "21_04#77 Maximum Battery Temperature"
+        )
 
         # LBC 21_07 balancing: summarize first few banks
-        bal1 = val("21_07_#03_Balancing Switch 1 Status") or val("21_07#03 Balancing Switch 1 Status")
-        bal2 = val("21_07_#04_Balancing Switch 2 Status") or val("21_07#04 Balancing Switch 2 Status")
-        bal3 = val("21_07_#05_Balancing Switch 3 Status") or val("21_07#05 Balancing Switch 3 Status")
+        bal1 = val("21_07_#03_Balancing Switch 1 Status") or val(
+            "21_07#03 Balancing Switch 1 Status"
+        )
+        bal2 = val("21_07_#04_Balancing Switch 2 Status") or val(
+            "21_07#04 Balancing Switch 2 Status"
+        )
+        bal3 = val("21_07_#05_Balancing Switch 3 Status") or val(
+            "21_07#05 Balancing Switch 3 Status"
+        )
 
         # Print summary
         print("Battery Health Snapshot")
@@ -196,8 +254,12 @@ def main() -> None:
         print(f"SOH: {soh if soh is not None else 'NA'} %")
         print(f"HV voltage: {hv_v if hv_v is not None else 'NA'} V")
         print(f"OCV: {ocv if ocv is not None else 'NA'} V")
-        print(f"Cell V min/max: {v_min if v_min is not None else 'NA'} / {v_max if v_max is not None else 'NA'} V")
-        print(f"Temps min/avg/max: {t_min if t_min is not None else 'NA'} / {t_avg if t_avg is not None else 'NA'} / {t_max if t_max is not None else 'NA'} °C")
+        print(
+            f"Cell V min/max: {v_min if v_min is not None else 'NA'} / {v_max if v_max is not None else 'NA'} V"
+        )
+        print(
+            f"Temps min/avg/max: {t_min if t_min is not None else 'NA'} / {t_avg if t_avg is not None else 'NA'} / {t_max if t_max is not None else 'NA'} °C"
+        )
         print(f"Balancing (banks 1-3): {bal1},{bal2},{bal3}")
         if getattr(client, "last_status", None):
             print(f"Status: {getattr(client, 'last_status', None)}")


### PR DESCRIPTION
## Summary
- clarify AT init sequence and wide CF fallback in UDS client and battery_health tool
- document wide CF fallback in README and sweep harness
- note AT timing defaults and Python differences in AGENTS report

## Testing
- `black PyCanZE/pycanze/uds.py PyCanZE/tools/battery_health.py`
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n PyCanZE/Testing/sweep_battery_health.sh`
- Attempted `apt-get update` (failed: repository not signed)
- Attempted `pip install shellcheck-py` (failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68b2ace8eba08330b08ca26a18f24207