### PR TITLE
Fix ISO-TP frame parsing for multi-frame UDS responses

### DIFF
--- a/PyCanZE/pycanze/test_uds.py
+++ b/PyCanZE/pycanze/test_uds.py
@@ -1,0 +1,30 @@
+import unittest
+from pycanze.uds import UDSClient, ELM_CMD_SLEEP
+
+class DummyClient(UDSClient):
+    def __init__(self):
+        super().__init__('0.0.0.0')
+        self.sock = object()
+        self._read_calls = 0
+    def _send(self, line: str, wait: float = ELM_CMD_SLEEP) -> None:
+        pass
+    def _read_lines(self, timeout: float | None = None):
+        self._read_calls += 1
+        if self._read_calls == 1:
+            return [
+                '10 0D 61 03 11 22 33 44',
+                '21 55 66 77 88 99 AA BB'
+            ]
+        return []
+
+class IsoTpReassemblyTest(unittest.TestCase):
+    def test_collects_consecutive_frames_present_in_first_read(self):
+        cli = DummyClient()
+        resp = cli._read_by_id(0x21, 0x03, 1)
+        self.assertEqual(resp, [
+            0x61, 0x03, 0x11, 0x22, 0x33, 0x44,
+            0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB
+        ])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/PyCanZE/pycanze/uds.py
+++ b/PyCanZE/pycanze/uds.py
@@ -449,12 +449,29 @@ class UDSClient:
         # (e.g. "03300000") is incorrect and can lead to "NO DATA" responses.
         if len(b) >= 3 and (b[0] >> 4) == 0x1:
             total_len = ((b[0] & 0x0F) << 8) | (b[1] & 0xFF)
+            collected: list[int] = []
             # Payload included in First Frame (starts at index 2)
-            collected: list[int] = list(b[2:])
+            take = min(6, len(b) - 2)
+            if take > 0:
+                collected.extend(b[2 : 2 + take])
+            j = 2 + take
+            expected_sn = 1
+            # Consume any Consecutive Frames already present in ``b``
+            while len(collected) < total_len and j < len(b):
+                pci = b[j]
+                if (pci >> 4) != 0x2:
+                    break
+                sn = pci & 0x0F
+                if sn != (expected_sn & 0x0F):
+                    return None
+                expected_sn = (expected_sn + 1) & 0x0F
+                take = min(7, len(b) - (j + 1), total_len - len(collected))
+                if take > 0:
+                    collected.extend(b[j + 1 : j + 1 + take])
+                j += 1 + take
             deadline = time.time() + float(
                 getattr(self, "isotp_collect_timeout_s", 2.5) or 2.5
             )
-            expected_sn = 1
             while len(collected) < total_len and time.time() < deadline:
                 try:
                     more = self._read_lines(


### PR DESCRIPTION
## Summary
- handle consecutive ISO-TP frames that arrive together from the ELM327 by stripping their PCI bytes before decoding
- add a regression unit test for ISO-TP reassembly

## Testing
- `python -m unittest pycanze/test_uds.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4292bbedc83309b6b8f28cb617a55