### PR TITLE
Add ReplayClient for canned UDS responses

### DIFF
--- a/PyCanZE/pycanze/__init__.py
+++ b/PyCanZE/pycanze/__init__.py
@@ -9,6 +9,7 @@ CSV files in :mod:`pycanze.data`.
 from .models import Ecu, Frame, Field
 from .parser import load_ecus, load_frames, load_fields, load_database
 from .uds import UDSClient
+from .replay_client import ReplayClient
 
 __all__ = [
     "Ecu",
@@ -19,4 +20,5 @@ __all__ = [
     "load_fields",
     "load_database",
     "UDSClient",
+    "ReplayClient",
 ]

--- a/PyCanZE/pycanze/replay_client.py
+++ b/PyCanZE/pycanze/replay_client.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""In-memory UDS client that replays canned responses.
+
+The :class:`ReplayClient` behaves like :class:`~pycanze.uds.UDSClient` but
+reads responses from a provided mapping instead of a real socket.  It is
+intended for unit tests and examples that need deterministic interaction
+without accessing a physical ELM327 dongle.
+
+Parameters
+----------
+responses:
+    Mapping of command hex strings to the list of response lines that
+    :meth:`_read_lines` should return.  Each key is the exact string passed to
+    :meth:`_send`.
+sid_responses:
+    Optional mapping of *service identifier* strings to response lines.  The
+    length byte normally prepended by :class:`UDSClient` is inserted
+    automatically.  For example::
+
+        client = ReplayClient(sid_responses={"10C0": ["50C0"]})
+        client._send("0210C0")
+        client._read_lines()  # -> ["50C0"]
+
+Unknown commands yield an empty list of lines.
+"""
+
+from typing import Dict, Mapping, Sequence, Optional, Union
+
+from .uds import UDSClient, ELM_CMD_SLEEP
+
+
+class ReplayClient(UDSClient):
+    """UDS client returning canned responses from a mapping."""
+
+    def __init__(
+        self,
+        responses: Optional[Mapping[str, Sequence[str]]] = None,
+        sid_responses: Optional[Mapping[str, Union[Sequence[str], str]]] = None,
+    ) -> None:
+        super().__init__("0.0.0.0")
+        # a dummy sock object satisfies UDSClient checks without networking
+        self.sock = object()
+        self._last_cmd = ""
+        self._responses: Dict[str, Sequence[str]] = {}
+        if responses:
+            for cmd, lines in responses.items():
+                self._responses[cmd.upper()] = list(lines)
+        if sid_responses:
+            for sid, lines in sid_responses.items():
+                # normalise service identifier and prepend length byte
+                norm = sid.strip().upper().replace(" ", "")
+                length = len(norm) // 2
+                cmd = f"{length:02X}{norm}"
+                if isinstance(lines, str):
+                    self._responses[cmd] = [lines]
+                else:
+                    self._responses[cmd] = list(lines)
+
+    # override socket helpers -------------------------------------------------
+    def _send(self, line: str, wait: float = ELM_CMD_SLEEP) -> None:  # type: ignore[override]
+        self._last_cmd = line.strip().upper().replace(" ", "")
+
+    def _read_lines(self, timeout: float | None = None):  # type: ignore[override]
+        return self._responses.get(self._last_cmd, [])

--- a/PyCanZE/pycanze/test_replay_client.py
+++ b/PyCanZE/pycanze/test_replay_client.py
@@ -1,0 +1,14 @@
+import unittest
+
+from pycanze.replay_client import ReplayClient
+
+
+class ReplayClientTest(unittest.TestCase):
+    def test_accepts_sid_mapping(self):
+        cli = ReplayClient(sid_responses={"10C0": ["50C0"]})
+        cli._send("0210C0")
+        self.assertEqual(cli._read_lines(), ["50C0"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add ReplayClient subclass to supply canned UDS responses for tests
- export ReplayClient at package level
- cover construction with a simple unit test

## Testing
- `PYTHONPATH=PyCanZE python -m pytest PyCanZE/pycanze/test_replay_client.py PyCanZE/pycanze/test_uds.py`

------
https://chatgpt.com/codex/tasks/task_e_68b49a9c176c8330835ce868093a1e58