### PR TITLE
Refine temperature field scaling and add regression tests

### DIFF
--- a/PyCanZE/pycanze/data/ZOE/EVC_Fields.csv
+++ b/PyCanZE/pycanze/data/ZOE/EVC_Fields.csv
@@ -101,7 +101,7 @@
 ,7EC,184,191,1,0,0,,21FF,61FF,ff,SaveMarking
 ,7EC,192,207,1,0,0,,21FF,61FF,4ff,CrcOfLogSave
 ,7EC,24,31,1,0,0,,222000,622000,4ff,DIDs supported in range [$2001 - $2020]
-,7EC,24,31,1,40,0,°C,222001,622001,ff,($2001) Battery Rack temperature
+,7EC,24,31,0.5,40,1,°C,222001,622001,ff,($2001) Battery Rack temperature
 ,7EC,24,39,.02,0,2,%,222002,622002,ff,($2002) State Of Charge (SOC) HV battery
 ,7EC,24,39,.01,0,2,km/h,222003,622003,ff,($2003) Vehicle speed
 ,7EC,24,39,.5,0,1,V,222004,622004,ff,($2004) consolidated HV voltage

--- a/PyCanZE/pycanze/data/ZOE/FFC_Fields.csv
+++ b/PyCanZE/pycanze/data/ZOE/FFC_Fields.csv
@@ -138,7 +138,7 @@
 ,42e,20,24,5,0,0,%,,,e2,Engine Fan Speed
 ,42e,25,34,0.5,0,0,V,,,ff,HV Network Voltage
 ,42e,38,43,1,0,1,A,,,e3,Charging Pilot Current
-,42e,44,50,1,40,0,°C,,,e3,HV Battery Temp
+,42e,44,50,0.5,40,1,°C,,,e3,HV Battery Temp
 ,42e,56,63,0.3,0,1,kW,,,ff,Charging Power
 ,430,0,9,10,0,0,rpm,,,e2,Clim Compressor Speed RPM Request 
 ,430,16,22,1,0,0,%,,,e2,High Voltage PTC Request PWM
@@ -172,7 +172,7 @@
 ,4f8,12,12,1,0,0,,,,ff,Cluster Driven Lamps Auto Check
 ,4f8,13,13,1,0,0,,,,ff,Displayed Speed Unit
 ,4f8,24,39,0.01,0,2,,,,ff,Speed on Display
-,534,32,40,1,40,0,°C,,,5,Temp out
+,534,32,40,0.5,40,1,°C,,,5,Temp out
 ,5d7,0,15,0.01,0,2,km/h,,,ff,Speed
 ,5d7,16,43,0.01,0,2,km,,,ff,Odometer
 ,5d7,50,54,0.04,0,2,cm,,,ff,Fine distance
@@ -293,7 +293,7 @@
 ,656,3,3,1,0,0,,,,ff,Trip Data Reset
 ,656,21,31,1,0,0,min,,,ff,Cluster Scheduled Time
 ,656,32,42,1,0,0,min,,,ff,Cluster Scheduled Time 2
-,656,48,55,1,40,0,°C,,,e2,External Temp
+,656,48,55,0.5,40,1,°C,,,e2,External Temp
 ,656,56,57,1,0,0,,,,e2,Clim PC Customer Activation
 ,657,0,1,1,0,0,,,,ff,PreHeatingActivationRequest
 ,657,8,9,1,0,0,,,,ff,PreHeatingActivationRequestedByKey

--- a/PyCanZE/pycanze/data/ZOE/_Fields.csv
+++ b/PyCanZE/pycanze/data/ZOE/_Fields.csv
@@ -16,14 +16,14 @@
 ,42e,0,12,0.02,0,2,%,,,e3,State of Charge
 ,42e,20,24,5,0,0,%,,,ff,Engine Fan Speed
 ,42e,38,43,1,0,1,A,,,e3,Charging Pilot Current
-,42e,44,50,1,40,0,°C,,,e3,HV Battery Temp
+,42e,44,50,0.5,40,1,°C,,,e3,HV Battery Temp
 ,42e,56,63,0.3,0,1,kW,,,ff,Charging Power
 ,430,24,33,0.5,30,1,°C,,,ff,Comp Temperature Discharge
 ,430,38,39,1,0,0,,,,ff,HV Battery Cooling State
 ,430,40,49,0.1,400,1,°C,,,ff,HV Battery Evaporator Temp
 ,432,36,37,1,0,0,,,,ff,HV Bat Conditionning Mode
 ,4f8,4,5,-1,-2,0,,,,ff,Parking Brake
-,534,32,40,1,40,0,°C,,,e5,Temp out
+,534,32,40,0.5,40,1,°C,,,e5,Temp out
 ,5d7,0,15,0.01,0,2,km/h,,,ff,Speed
 ,5da,0,7,1,40,0,ºC,,,e7,Water temperature
 ,62d,0,9,0.1,0,1,kWh/100km,,,ff,Worst Average Consumption
@@ -33,7 +33,7 @@
 ,654,32,41,1,0,0,min,,,ff,Time to Full
 ,654,42,51,1,0,0,km,,,ff,Available Distance
 ,654,52,61,0.1,0,1,kWh/100km,,,ff,Average Consumption
-,656,48,55,1,40,0,°C,,,ff,External Temp
+,656,48,55,0.5,40,1,°C,,,ff,External Temp
 ,658,33,39,1,0,0,%,,,ff,Battery Health
 ,673,0,0,1,0,0,,,,ff,Speed pressure misadaptation
 ,673,2,4,1,0,0,,,,ff,Rear right wheel state

--- a/PyCanZE/pycanze/tests/test_evc_fields.py
+++ b/PyCanZE/pycanze/tests/test_evc_fields.py
@@ -1,0 +1,30 @@
+import sys
+from pathlib import Path
+import pytest
+
+# ensure package path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from pycanze.replay_client import ReplayClient
+from pycanze.uds import UDSClient
+
+
+def test_evc_soc_scaling() -> None:
+    client = ReplayClient(responses={"03222002": ["62 20 02 08 D8"]})
+    value = client.read_field("7EC.24.622002")
+    assert value == pytest.approx(45.28)
+
+
+def test_evc_battery_rack_temperature() -> None:
+    client = ReplayClient(responses={"03222001": ["62 20 01 50"]})
+    value = client.read_field("7EC.24.622001")
+    assert value == pytest.approx(20.0)
+
+
+def test_free_frame_hv_battery_temp() -> None:
+    client = ReplayClient()
+    field = client.fields["42e.44."]
+    frame = bytes.fromhex("0000000000078000")
+    raw = UDSClient._extract_bits(frame, field.start_bit, field.end_bit)
+    value = (raw - field.offset) * field.resolution
+    assert value == pytest.approx(10.0)


### PR DESCRIPTION
## Summary
- adjust HV battery and ambient temperature offsets to half-degree resolution in CSV definitions
- apply the same scaling to EVC battery rack temperature
- add regression tests for SOC, battery rack temperature and raw HV battery temperature frames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4a3a20afc8330a54223d6b69d4cf5