### PR TITLE
Add SID decoding summary to tests

### DIFF
--- a/PyCanZE/pycanze/tests/conftest.py
+++ b/PyCanZE/pycanze/tests/conftest.py
@@ -1,0 +1,16 @@
+from pycanze.tests.test_sid_decoding import MISSING_DB_SIDS, MISMATCHES
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Emit a summary of missing SIDs and decoding mismatches."""
+    if MISSING_DB_SIDS:
+        print("\nSIDs missing from CSV definitions:")
+        for sid in sorted(MISSING_DB_SIDS):
+            print(f"  {sid}")
+    if MISMATCHES:
+        print("\nSIDs with decoding mismatches:")
+        print("SID\tExpected\tActual\tUnit")
+        for sid, (expected, actual, unit) in sorted(MISMATCHES.items()):
+            print(f"{sid}\t{expected}\t{actual}\t{unit}")
+    if not MISSING_DB_SIDS and not MISMATCHES:
+        print("\nAll SIDs accounted for and decoded correctly.")

--- a/PyCanZE/pycanze/tests/test_sid_decoding.py
+++ b/PyCanZE/pycanze/tests/test_sid_decoding.py
@@ -12,6 +12,11 @@ from pycanze.uds import UDSClient, ELM_CMD_SLEEP
 from pycanze.replay_client import ReplayClient as ReplayUDSClient
 
 
+# Lists used for summary reporting after the SID decoding tests run
+MISSING_DB_SIDS: set[str] = set()
+MISMATCHES: dict[str, tuple[float, float | None, str | None]] = {}
+
+
 # ---------------------------------------------------------------------------
 # Frame reassembly
 # ---------------------------------------------------------------------------
@@ -132,6 +137,7 @@ def _collect_cases(limit_per_file: int = 10):
                 continue
             field = fields.get(sid)
             if field is None:
+                MISSING_DB_SIDS.add(sid)
                 if not missing_db:
                     cases.append(
                         pytest.param(
@@ -170,6 +176,8 @@ def _collect_cases(limit_per_file: int = 10):
             client = ReplayUDSClient(responses=mapping)
             result = client.read_field(sid)
             if result is None or not math.isclose(result, float(value), rel_tol=1e-5, abs_tol=1e-5):
+                if sid not in MISMATCHES:
+                    MISMATCHES[sid] = (float(value), float(result) if result is not None else None, unit)
                 continue
             cases.append((sid, float(value), unit, mapping))
             count += 1


### PR DESCRIPTION
## Summary
- track SIDs missing from CSV definitions and decode mismatches during SID tests
- emit a post-test summary listing missing and mismatched SIDs

## Testing
- `pytest pycanze/tests/test_sid_decoding.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4a79c52fc833093d50f005177694a