### PR TITLE
Fix field lookup by normalising SIDs and CSV priority

### DIFF
--- a/PyCanZE/pycanze/parser.py
+++ b/PyCanZE/pycanze/parser.py
@@ -111,7 +111,19 @@ def load_fields(base_dir: Path = DATA_DIR) -> Tuple[Dict[str, Field], Dict[str, 
     by_name: Dict[str, Field] = {}
 
     for vehicle_dir in base_dir.iterdir():
-        for csv_file in vehicle_dir.glob("*_Fields.csv"):
+        # Ensure a deterministic load order: process the generic ``_Fields.csv``
+        # first so that ECU specific files (e.g. ``EVC_Fields.csv``) can
+        # override entries with more accurate metadata.  Without this explicit
+        # ordering the iteration order of :func:`Path.glob` depends on the
+        # underlying filesystem which can lead to different files winning when
+        # duplicate SIDs exist.  In practice this meant that some fields picked
+        # up offsets or resolutions from the catch‑all ``_Fields.csv`` instead of
+        # the ECU specific definitions used by the Android implementation.
+        field_files = sorted(
+            vehicle_dir.glob("*_Fields.csv"),
+            key=lambda p: (p.name != "_Fields.csv", p.name),
+        )
+        for csv_file in field_files:
             for row in _read_csv(csv_file):
                 row += [""] * (13 - len(row))
                 (
@@ -138,6 +150,7 @@ def load_fields(base_dir: Path = DATA_DIR) -> Tuple[Dict[str, Field], Dict[str, 
                 decimals = int(decimals_s) if decimals_s else 0
                 options = [options_s[i : i + 2] for i in range(0, len(options_s), 2)] if options_s else []
                 sid = sid or f"{frame_id_s}.{start_bit_s}.{response_id}"
+                sid = sid.lower()
                 field = Field(
                     sid=sid,
                     frame_id=frame_id,


### PR DESCRIPTION
## Summary
- ensure `_Fields.csv` loads before ECU-specific files so precise definitions override
- normalise generated SIDs to lowercase to avoid duplicate mismatches

## Testing
- `PYTHONPATH=.. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest --noconftest tests/generated/test_sid_7ec_128_6180.py -q`
- `python - <<'PY'
import sys
sys.path.append('..')
from pycanze.replay_client import ReplayClient
client = ReplayClient(sid_responses={'223319': ['0462331900AAAAAA'], '223318':['0462331814AAAAAA'], '223484':['056234848096AAAA']})
print('623319:', client.read_field('7ec.24.623319'))
print('623318:', client.read_field('7ec.24.623318'))
print('623484:', client.read_field('7ec.24.623484'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68b53f67632483309e669789f5ab1494