### PR TITLE
Handle signed and string field decoding

### DIFF
--- a/PyCanZE/pycanze/tests/test_sid_decoding.py
+++ b/PyCanZE/pycanze/tests/test_sid_decoding.py
@@ -158,16 +158,25 @@ def _collect_cases(limit_per_file: int = 10):
                 continue
             client = ReplayUDSClient(responses=mapping, fields=fields)
             result = client.read_field(sid)
-            if result is None or not math.isclose(result, float(value), rel_tol=1e-5, abs_tol=1e-5):
+            try:
+                expected_val = float(value)
+            except Exception:
+                # Skip non-numeric values (string/hex fields)
+                continue
+            if (
+                result is None
+                or not isinstance(result, (int, float))
+                or not math.isclose(result, expected_val, rel_tol=1e-5, abs_tol=1e-5)
+            ):
                 if sid not in MISMATCHES:
                     MISMATCHES[sid] = (
-                        float(value),
-                        float(result) if result is not None else None,
+                        expected_val,
+                        float(result) if isinstance(result, (int, float)) else result,
                         unit,
                         field.name,
                     )
                 continue
-            cases[sid] = (float(value), unit, mapping)
+            cases[sid] = (expected_val, unit, mapping)
             if len(cases) >= limit_per_file:
                 break
     for sid, name in missing_from_logs.items():

--- a/PyCanZE/pycanze/tests/test_signed_and_string_fields.py
+++ b/PyCanZE/pycanze/tests/test_signed_and_string_fields.py
@@ -1,0 +1,27 @@
+from pycanze.replay_client import ReplayClient as ReplayUDSClient
+import pytest
+from pycanze.parser import load_fields
+
+
+def test_signed_field_sign_extension():
+    by_sid, _ = load_fields()
+    client = ReplayUDSClient(
+        sid_responses={"223018": ["05623018FFF6"]}, fields=by_sid
+    )
+    assert client.read_field("77e.24.623018") == pytest.approx(-0.16)
+
+
+def test_string_field_decoding():
+    by_sid, _ = load_fields()
+    client = ReplayUDSClient(
+        sid_responses={
+            "2181": [
+                "1015618156463141",
+                "2147565946303630",
+                "22343839313133FF",
+                "23D3AAAAAAAAAAAA",
+            ]
+        },
+        fields=by_sid,
+    )
+    assert client.read_field("7ec.16.6181") == "VF1AGVYF060489113"

--- a/PyCanZE/pycanze/uds.py
+++ b/PyCanZE/pycanze/uds.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import socket
 import os
 import time
-from typing import Dict, Optional, Sequence
+from typing import Dict, Optional, Sequence, Union
 
 try:  # optional dependency for proper ELM327 management
     from obd_wifi.elm327 import ELM327  # type: ignore
@@ -755,11 +755,11 @@ class UDSClient:
         return value & mask
 
     # ------------------------------------------------------------------
-    def read_field(self, sid: str) -> Optional[float]:
+    def read_field(self, sid: str) -> Optional[Union[float, str]]:
         """Read and decode a diagnostic field by its SID.
 
-        Returns the scaled value or ``None`` if the ECU returned a negative
-        response.
+        Returns the scaled value, decoded string/hex string or ``None`` if the
+        ECU returned a negative response.
         """
 
         field = self.fields.get(sid)
@@ -791,14 +791,29 @@ class UDSClient:
         total_bits = len(resp) * 8
         if total_bits <= field.end_bit:
             return None
-        raw_value = self._extract_bits(bytes(resp), field.start_bit, field.end_bit)
-        # Treat all-ones patterns as N/A when indicated (CSV often marks with 'ff')
+        data = bytes(resp)
         width = max(1, int(field.end_bit) - int(field.start_bit) + 1)
-        all_ones = (1 << width) - 1 if width < 32 else 0xFFFFFFFF
         optmask = field.options or 0
-        # Consider car mask 0xFF as the original 'ff' sentinel or use width-based heuristic
+        # String / hex-string fields return decoded text or hex
+        if field.is_string() or field.is_hex_string():
+            start_byte = int(field.start_bit) // 8
+            end_byte = int(field.end_bit) // 8
+            raw = data[start_byte : end_byte + 1]
+            if raw and all(b == 0xFF for b in raw):
+                return None
+            if field.is_string():
+                return raw.rstrip(b"\x00").decode("latin-1", errors="ignore")
+            return raw.hex()
+        raw_value = self._extract_bits(data, field.start_bit, field.end_bit)
+        # Treat all-ones patterns as N/A when indicated (CSV often marks with 'ff')
+        all_ones = (1 << width) - 1 if width < 32 else 0xFFFFFFFF
         if raw_value == all_ones and ((optmask & 0xFF) == 0xFF or width in (8, 16, 32)):
             return None
+        # Signed fields use two's complement
+        if field.is_signed():
+            sign_bit = 1 << (width - 1)
+            if raw_value & sign_bit:
+                raw_value -= 1 << width
         # Apply Android semantics: value = (raw - offset) * resolution
         try:
             value = (raw_value - float(field.offset)) * float(field.resolution)


### PR DESCRIPTION
## Summary
- sign-extend negative values before scaling
- decode string and hex-string fields to text
- add tests for signed and string field decoding

## Testing
- `PYTHONPATH=PyCanZE pytest PyCanZE/pycanze/tests/test_signed_and_string_fields.py PyCanZE/pycanze/tests/generated/test_sid_7bb_976_6169.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b578003f008330a2a0607639cabff2