### PR TITLE
Handle all-ones wider fields

### DIFF
--- a/PyCanZE/pycanze/tests/test_all_ones.py
+++ b/PyCanZE/pycanze/tests/test_all_ones.py
@@ -1,0 +1,44 @@
+from pycanze.models import Field
+from pycanze.replay_client import ReplayClient as ReplayUDSClient
+
+
+def _mk_field(sid, start_bit, end_bit, request_id, options=0):
+    return Field(
+        sid=sid,
+        frame_id=0x7E8,
+        start_bit=start_bit,
+        end_bit=end_bit,
+        resolution=1.0,
+        offset=0.0,
+        decimals=0,
+        unit="",
+        request_id=request_id,
+        response_id=None,
+        options=options,
+    )
+
+
+def test_all_ones_width_ge_5_returns_none():
+    field = _mk_field("test.ge5", 24, 31, "220001")
+    client = ReplayUDSClient(
+        sid_responses={"220001": ["04620001FF"]}, fields={field.sid: field}
+    )
+    assert client.read_field(field.sid) is None
+
+
+def test_all_ones_width_le_4_valid():
+    field = _mk_field("test.le4", 28, 31, "220002")
+    client = ReplayUDSClient(
+        sid_responses={"220002": ["046200020F"]}, fields={field.sid: field}
+    )
+    assert client.read_field(field.sid) == 0xF
+
+
+def test_string_field_all_ones_returns_none():
+    field = _mk_field(
+        "test.str", 24, 39, "220003", options=Field.FIELD_TYPE_STRING
+    )
+    client = ReplayUDSClient(
+        sid_responses={"220003": ["05620003FFFF"]}, fields={field.sid: field}
+    )
+    assert client.read_field(field.sid) is None

--- a/PyCanZE/pycanze/uds.py
+++ b/PyCanZE/pycanze/uds.py
@@ -793,22 +793,17 @@ class UDSClient:
             return None
         data = bytes(resp)
         width = max(1, int(field.end_bit) - int(field.start_bit) + 1)
-        optmask = field.options or 0
+        start_byte = int(field.start_bit) // 8
+        end_byte = int(field.end_bit) // 8
+        raw = data[start_byte : end_byte + 1]
+        raw_value = self._extract_bits(data, field.start_bit, field.end_bit)
+        if width >= 5 and raw_value == (1 << width) - 1:
+            return None
         # String / hex-string fields return decoded text or hex
         if field.is_string() or field.is_hex_string():
-            start_byte = int(field.start_bit) // 8
-            end_byte = int(field.end_bit) // 8
-            raw = data[start_byte : end_byte + 1]
-            if raw and all(b == 0xFF for b in raw):
-                return None
             if field.is_string():
                 return raw.rstrip(b"\x00").decode("latin-1", errors="ignore")
             return raw.hex()
-        raw_value = self._extract_bits(data, field.start_bit, field.end_bit)
-        # Treat all-ones patterns as N/A when indicated (CSV often marks with 'ff')
-        all_ones = (1 << width) - 1 if width < 32 else 0xFFFFFFFF
-        if raw_value == all_ones and ((optmask & 0xFF) == 0xFF or width in (8, 16, 32)):
-            return None
         # Signed fields use two's complement
         if field.is_signed():
             sign_bit = 1 << (width - 1)


### PR DESCRIPTION
## Summary
- Suppress ≥5-bit all-ones values in `UDSClient.read_field` before type decoding
- Add tests covering suppression of wide all-ones values and preservation of 4-bit values

## Testing
- `pytest PyCanZE/pycanze/tests/test_all_ones.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b57d7597bc83309337ccf22b43a645