### PR TITLE
Add ReplayClient state detection tests

### DIFF
--- a/PyCanZE/pycanze/tests/__init__.py
+++ b/PyCanZE/pycanze/tests/__init__.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Callable, Mapping, Sequence
+
+import pytest
+
+from pycanze.models import Field
+from pycanze.replay_client import ReplayClient
+
+
+@pytest.fixture
+def mk_replay_client() -> Callable[[Mapping[str, Sequence[str]]], ReplayClient]:
+    """Factory yielding :class:`ReplayClient` preloaded with common fields."""
+
+    fields = {
+        "soc": Field(
+            sid="soc",
+            frame_id=0x7EC,
+            start_bit=24,
+            end_bit=39,
+            resolution=1.0,
+            offset=0.0,
+            decimals=0,
+            unit="%",
+            request_id="222002",
+            response_id=None,
+            options=0,
+        ),
+        "pump": Field(
+            sid="pump",
+            frame_id=0x7EC,
+            start_bit=24,
+            end_bit=31,
+            resolution=1.0,
+            offset=0.0,
+            decimals=0,
+            unit="%",
+            request_id="223319",
+            response_id=None,
+            options=0,
+        ),
+    }
+
+    def _factory(responses: Mapping[str, Sequence[str]]) -> ReplayClient:
+        return ReplayClient(sid_responses=responses, fields=fields)
+
+    return _factory

--- a/PyCanZE/pycanze/tests/test_state_detection.py
+++ b/PyCanZE/pycanze/tests/test_state_detection.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from . import mk_replay_client
+
+
+def detect_state(client):
+    """Return (state, soc) from canned diagnostic fields."""
+
+    soc = client.read_field("soc")
+    pump = client.read_field("pump")
+    if pump and pump > 0:
+        return "charging", soc
+    if soc == 0:
+        return "charger_connected_sleep", None
+    return "ready", soc
+
+
+def test_ready_state(mk_replay_client):
+    client = mk_replay_client({
+        "222002": ["056220020050"],  # SOC 80%
+        "223319": ["0462331900"],   # pump idle
+    })
+    state, soc = detect_state(client)
+    assert state == "ready"
+    assert soc == 80
+
+
+def test_charging_state(mk_replay_client):
+    client = mk_replay_client({
+        "222002": ["056220020028"],  # SOC 40%
+        "223319": ["046233190A"],   # pump active
+    })
+    state, soc = detect_state(client)
+    assert state == "charging"
+    assert soc == 40
+
+
+def test_charger_connected_sleep_sentinel(mk_replay_client):
+    client = mk_replay_client({
+        "222002": ["056220020000"],  # SOC sentinel 0%
+        "223319": ["0462331900"],   # pump idle
+    })
+    state, soc = detect_state(client)
+    assert state == "charger_connected_sleep"
+    assert soc is None


### PR DESCRIPTION
## Summary
- add ReplayClient factory fixture with SOC and pump fields
- verify state detection for ready, charging, and charger-connected sleep scenarios and skip sentinel SOC

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9e4545b3883308f6f4e75a12e5ee5