### PR TITLE
Add CAN sniffing helper and CLI tool

### DIFF
--- a/PyCanZE/README.md
+++ b/PyCanZE/README.md
@@ -53,7 +53,7 @@ This repository also contains a Python toolkit under `PyCanZE/` used for command
 
 These apply to the Python command‑line tools under `PyCanZE/` and do not affect the Android app:
 
-- No free‑frame capture yet: the tools do not use `ATMA` to sniff broadcast frames. They focus on on‑demand UDS reads (0x21/0x22). This mainly impacts “live dashboard” use cases that rely on high‑rate broadcast messages. It does not affect the planned Home Assistant integration or periodic snapshots (EVC‑based SoC/SOH/HV/odometer are supported).
+- Raw frame sniffing via `tools/sniff_frames.py` uses `ATMA` to monitor bus traffic. It does not perform ISO‑TP reassembly and is read‑only (no frame injection).
 - 11‑bit CAN only: extended (29‑bit) ISO‑TP addressing (`ATSP7` + `ATCP`) isn’t implemented yet. Legacy ZOE and Twingo 3 Ph2 battery ECUs use 11‑bit and are supported. ZOE Ph2 battery ECUs (e.g., LBC/LBC2 with 29‑bit IDs) are not yet reachable from the Python tools.
 
 These gaps are intentional for now. Primary goal is HA integration and basic diagnostics; there’s no intent to build a live driving dashboard. If needed later, both features can be added behind flags with per‑ECU selection from the CSV database.

--- a/PyCanZE/pycanze/uds.py
+++ b/PyCanZE/pycanze/uds.py
@@ -22,7 +22,8 @@ from __future__ import annotations
 import socket
 import os
 import time
-from typing import Dict, Optional, Sequence, Union
+import threading
+from typing import Callable, Dict, Iterator, Optional, Sequence, Tuple, Union
 
 try:  # optional dependency for proper ELM327 management
     from obd_wifi.elm327 import ELM327  # type: ignore
@@ -110,6 +111,9 @@ class UDSClient:
         self.cf_read_timeout_s = 1.2  # per read timeout while collecting CFs
         # Optional per-ECU first-0x21 delay (currently used for LBC 0x7BB)
         self.first_21_delay_by_req = {}
+        # Sniffing state
+        self._sniffing = False
+        self._sniff_thread: Optional[threading.Thread] = None
 
     # sleep hook -------------------------------------------------------------
     def _sleep(self, duration: float) -> None:
@@ -388,6 +392,88 @@ class UDSClient:
         if self.sock is not None:
             self.sock.close()
             self.sock = None
+
+    # ------------------------------------------------------------------
+    def _sniff_loop(self) -> Iterator[Tuple[int, bytes]]:
+        """Internal generator yielding ``(frame_id, payload)`` tuples."""
+
+        assert self.sock is not None
+        self._sniffing = True
+        self._send("ATMA", wait=0.0)
+        self.sock.settimeout(0.2)
+        buf = b""
+        while self._sniffing:
+            try:
+                chunk = self.sock.recv(4096)
+            except Exception:
+                continue
+            if not chunk:
+                continue
+            buf += chunk
+            while b"\r" in buf or b"\n" in buf:
+                for sep in (b"\r", b"\n"):
+                    if sep in buf:
+                        line, buf = buf.split(sep, 1)
+                        break
+                text = line.decode(errors="ignore").strip()
+                if not text or text == ">" or "STOPPED" in text:
+                    continue
+                parts = text.split()
+                try:
+                    fid = int(parts[0], 16)
+                    payload = bytes(int(p, 16) for p in parts[1:])
+                except Exception:
+                    continue
+                yield fid, payload
+        try:
+            self.sock.settimeout(self.timeout)
+        except Exception:
+            pass
+
+    def start_sniffing(
+        self, callback: Optional[Callable[[int, bytes], None]] = None
+    ) -> Iterator[Tuple[int, bytes]] | None:
+        """Start ``ATMA`` sniffing.
+
+        If ``callback`` is provided, frames are delivered via the function in a
+        background thread and the method returns ``None``. Otherwise an iterator
+        yielding ``(frame_id, payload)`` tuples is returned and should be
+        consumed by the caller. Call :meth:`stop_sniffing` to stop.
+        """
+
+        if self.sock is None:
+            raise RuntimeError("connect() must be called before sniffing")
+        if callback is None:
+            return self._sniff_loop()
+
+        def _run() -> None:
+            for fid, payload in self._sniff_loop():
+                callback(fid, payload)
+
+        self._sniff_thread = threading.Thread(target=_run, daemon=True)
+        self._sniff_thread.start()
+        return None
+
+    def stop_sniffing(self) -> None:
+        """Stop active ``ATMA`` sniffing."""
+
+        if not self._sniffing:
+            return
+        self._sniffing = False
+        if self.sock is not None:
+            try:
+                self.sock.sendall(b"\x03")  # Ctrl+C abort
+                # Flush any remaining lines including the prompt
+                self.sock.settimeout(0.2)
+                try:
+                    self.sock.recv(4096)
+                except Exception:
+                    pass
+            except Exception:
+                pass
+        if self._sniff_thread is not None:
+            self._sniff_thread.join(timeout=1.0)
+            self._sniff_thread = None
 
     # ------------------------------------------------------------------
     def _read_by_id(

--- a/PyCanZE/tools/sniff_frames.py
+++ b/PyCanZE/tools/sniff_frames.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Simple CLI to sniff raw CAN frames using UDSClient.start_sniffing."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running from repository root without installation
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+from pycanze import UDSClient  # type: ignore
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Sniff raw CAN frames via ATMA")
+    parser.add_argument("--host", default="192.168.2.21", help="ELM327 host")
+    parser.add_argument("--port", type=int, default=35000, help="ELM327 TCP port")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    client = UDSClient(args.host, port=args.port)
+    client.connect()
+    client.initialize()
+    try:
+        for fid, payload in client.start_sniffing():
+            payload_hex = " ".join(f"{b:02X}" for b in payload)
+            print(f"{fid:03X} {payload_hex}")
+    except KeyboardInterrupt:
+        pass
+    finally:
+        client.stop_sniffing()
+        client.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `start_sniffing`/`stop_sniffing` to `UDSClient` for ATMA frame monitoring
- provide `tools/sniff_frames.py` showcasing raw frame capture
- document sniffing limitations (no ISO-TP reassembly, read-only) in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b9e6f6242883308116647074f62d37