### PR TITLE
Add vehicle state helper module and tests

### DIFF
--- a/PyCanZE/pycanze/mqtt_poller.py
+++ b/PyCanZE/pycanze/mqtt_poller.py
@@ -9,37 +9,13 @@ import os
 import socket
 import time
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import paho.mqtt.client as mqtt
 
 from pycanze import UDSClient  # type: ignore
 from pycanze.parser import load_fields  # type: ignore
-
-# Core SIDs
-SID_SOC = "7ec.24.622002"
-SID_SOC_MEM = "7ec.168.623415"
-SID_SOH = "7ec.24.623206"
-SID_HV_V = "7ec.24.623203"
-SID_ODO = "7ec.24.623200"  # some datasets use 7ec.24.622006
-SID_CHG_MODE = "7ec.30.6234dd"
-SID_CHG_SET = "7ec.24.6234ad"
-SID_HVAC_REQ = "7ec.31.6233cd"
-SID_HEAT_REQ = "7ec.25.623328"
-SID_KEY_STATE = "7ec.31.62200e"
-
-POLL_SIDS = [
-    SID_SOC,
-    SID_SOC_MEM,
-    SID_SOH,
-    SID_HV_V,
-    SID_ODO,
-    SID_CHG_MODE,
-    SID_CHG_SET,
-    SID_HVAC_REQ,
-    SID_HEAT_REQ,
-    SID_KEY_STATE,
-]
+from pycanze.state import POLL_SIDS, build_payload, detect_state
 
 
 def _safe_read(client: UDSClient, sid: str) -> Optional[float]:
@@ -58,52 +34,6 @@ def _safe_read(client: UDSClient, sid: str) -> Optional[float]:
         return None
 
 
-def detect_state(vals: Dict[str, Optional[float]]) -> str:
-    """Return vehicle state based on heuristic signals."""
-
-    key = vals.get(SID_KEY_STATE)
-    chg_mode = vals.get(SID_CHG_MODE)
-    chg_set = vals.get(SID_CHG_SET)
-    soc = vals.get(SID_SOC)
-    hvac = vals.get(SID_HVAC_REQ)
-    heat = vals.get(SID_HEAT_REQ)
-
-    if key == 1:
-        return "ready"
-    if chg_mode == 2 or (chg_set is not None and chg_set > 0):
-        return "charging"
-    if soc == 0:
-        if hvac == 1 or heat == 0:
-            return "charger_connected_sleep"
-        return "parked_sleep"
-    return "parked"
-
-
-def build_payload(vals: Dict[str, Optional[float]], state: str) -> Dict[str, object]:
-    """Filter sentinel values and construct payload."""
-
-    soc = vals.get(SID_SOC)
-    soc_mem = vals.get(SID_SOC_MEM)
-    if soc in (None, 0) and soc_mem not in (None, 0):
-        soc = soc_mem
-
-    soh = vals.get(SID_SOH)
-    hv = vals.get(SID_HV_V)
-    odo = vals.get(SID_ODO)
-
-    data: Dict[str, object] = {"state": state}
-    if soc not in (None, 0):
-        data["soc"] = round(float(soc), 3)
-    if soh is not None and soh <= 100:
-        data["soh"] = round(float(soh), 3)
-    if hv is not None and hv < 500:
-        data["hv_voltage"] = round(float(hv), 3)
-    if odo is not None:
-        try:
-            data["odometer"] = int(odo)
-        except Exception:
-            pass
-    return data
 
 
 def parse_args() -> argparse.Namespace:

--- a/PyCanZE/pycanze/state.py
+++ b/PyCanZE/pycanze/state.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Dict, Optional, Any
+
+# Diagnostic field identifiers used for state detection and payload building
+SID_SOC = "7ec.24.622002"
+SID_SOC_MEM = "7ec.168.623415"
+SID_SOH = "7ec.24.623206"
+SID_HV_V = "7ec.24.623203"
+SID_ODO = "7ec.24.623200"  # some datasets use 7ec.24.622006
+SID_CHG_MODE = "7ec.30.6234dd"
+SID_CHG_SET = "7ec.24.6234ad"
+SID_HVAC_REQ = "7ec.31.6233cd"
+SID_HEAT_REQ = "7ec.25.623328"
+SID_KEY_STATE = "7ec.31.62200e"
+
+POLL_SIDS = [
+    SID_SOC,
+    SID_SOC_MEM,
+    SID_SOH,
+    SID_HV_V,
+    SID_ODO,
+    SID_CHG_MODE,
+    SID_CHG_SET,
+    SID_HVAC_REQ,
+    SID_HEAT_REQ,
+    SID_KEY_STATE,
+]
+
+
+def detect_state(vals: Dict[str, Optional[float]]) -> str:
+    """Return vehicle state based on heuristic signals."""
+
+    key = vals.get(SID_KEY_STATE)
+    chg_mode = vals.get(SID_CHG_MODE)
+    chg_set = vals.get(SID_CHG_SET)
+    soc = vals.get(SID_SOC)
+    hvac = vals.get(SID_HVAC_REQ)
+    heat = vals.get(SID_HEAT_REQ)
+
+    if key == 1:
+        return "ready"
+    if chg_mode == 2 or (chg_set is not None and chg_set > 0):
+        return "charging"
+    if soc == 0:
+        if hvac == 1 or heat == 0:
+            return "charger_connected_sleep"
+        return "parked_sleep"
+    return "parked"
+
+
+def select_soc(soc: Optional[float], soc_mem: Optional[float]) -> Optional[float]:
+    """Prefer memorised SOC when the direct read returns a sentinel."""
+
+    if soc in (None, 0) and soc_mem not in (None, 0):
+        return soc_mem
+    return soc
+
+
+def filter_soh(soh: Optional[float]) -> Optional[float]:
+    """Discard implausible SOH readings."""
+
+    if soh is None or soh > 100:
+        return None
+    return soh
+
+
+def filter_hv_voltage(hv: Optional[float]) -> Optional[float]:
+    """Discard placeholder HV voltage readings."""
+
+    if hv is None or hv >= 500:
+        return None
+    return hv
+
+
+def filter_odometer(odo: Optional[float]) -> Optional[int]:
+    """Convert odometer to int, ignoring failures."""
+
+    if odo is None:
+        return None
+    try:
+        return int(odo)
+    except Exception:
+        return None
+
+
+def build_payload(vals: Dict[str, Optional[float]], state: str) -> Dict[str, Any]:
+    """Filter sentinel values and construct payload."""
+
+    soc = select_soc(vals.get(SID_SOC), vals.get(SID_SOC_MEM))
+    soh = filter_soh(vals.get(SID_SOH))
+    hv = filter_hv_voltage(vals.get(SID_HV_V))
+    odo = filter_odometer(vals.get(SID_ODO))
+
+    data: Dict[str, Any] = {"state": state}
+    if soc not in (None, 0):
+        data["soc"] = round(float(soc), 3)
+    if soh is not None:
+        data["soh"] = round(float(soh), 3)
+    if hv is not None:
+        data["hv_voltage"] = round(float(hv), 3)
+    if odo is not None:
+        data["odometer"] = odo
+    return data

--- a/PyCanZE/tests/test_state.py
+++ b/PyCanZE/tests/test_state.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from typing import Dict
+
+from pycanze.models import Field
+from pycanze.replay_client import ReplayClient
+from pycanze import state as st
+
+
+def _mk_field(sid: str, request_id: str, width: int) -> Field:
+    start_bit = 24
+    end_bit = start_bit + width * 8 - 1
+    return Field(
+        sid=sid,
+        frame_id=0x7EC,
+        start_bit=start_bit,
+        end_bit=end_bit,
+        resolution=1.0,
+        offset=0.0,
+        decimals=0,
+        unit="",
+        request_id=request_id,
+        response_id=None,
+        options=0,
+    )
+
+
+FIELDS: Dict[str, Field] = {
+    st.SID_SOC: _mk_field(st.SID_SOC, "222002", 2),
+    st.SID_SOC_MEM: _mk_field(st.SID_SOC_MEM, "223415", 2),
+    st.SID_SOH: _mk_field(st.SID_SOH, "223206", 1),
+    st.SID_HV_V: _mk_field(st.SID_HV_V, "223203", 2),
+    st.SID_ODO: _mk_field(st.SID_ODO, "223200", 1),
+    st.SID_CHG_MODE: _mk_field(st.SID_CHG_MODE, "2234DD", 1),
+    st.SID_CHG_SET: _mk_field(st.SID_CHG_SET, "2234AD", 2),
+    st.SID_HVAC_REQ: _mk_field(st.SID_HVAC_REQ, "2233CD", 1),
+    st.SID_HEAT_REQ: _mk_field(st.SID_HEAT_REQ, "223328", 1),
+    st.SID_KEY_STATE: _mk_field(st.SID_KEY_STATE, "22200E", 1),
+}
+
+
+def _encode(req: str, val: int, size: int) -> str:
+    did = req[2:]
+    length = 4 if size == 1 else 5
+    data = f"{val:0{size * 2}X}"
+    return f"{length:02X}62{did}{data}"
+
+
+def make_client(values: Dict[str, int]) -> ReplayClient:
+    responses = {}
+    for sid, field in FIELDS.items():
+        req = field.request_id or ""
+        width = field.end_bit - field.start_bit + 1
+        size = 2 if width > 8 else 1
+        val = values.get(sid, 0)
+        responses[req] = [_encode(req, int(val), size)]
+    return ReplayClient(sid_responses=responses, fields=FIELDS)
+
+
+def gather(client: ReplayClient) -> Dict[str, float | None]:
+    return {sid: client.read_field(sid) for sid in st.POLL_SIDS}
+
+
+def test_ready_state():
+    client = make_client({
+        st.SID_KEY_STATE: 1,
+        st.SID_SOC: 80,
+        st.SID_SOC_MEM: 80,
+    })
+    vals = gather(client)
+    state = st.detect_state(vals)
+    payload = st.build_payload(vals, state)
+    assert state == "ready"
+    assert payload["soc"] == 80
+
+
+def test_charging_state():
+    client = make_client({
+        st.SID_CHG_MODE: 2,
+        st.SID_SOC: 40,
+        st.SID_SOC_MEM: 40,
+    })
+    vals = gather(client)
+    state = st.detect_state(vals)
+    payload = st.build_payload(vals, state)
+    assert state == "charging"
+    assert payload["soc"] == 40
+
+
+def test_sleep_state_uses_mem_soc():
+    client = make_client({
+        st.SID_SOC: 0,
+        st.SID_SOC_MEM: 70,
+        st.SID_HVAC_REQ: 1,
+        st.SID_HEAT_REQ: 0,
+    })
+    vals = gather(client)
+    state = st.detect_state(vals)
+    payload = st.build_payload(vals, state)
+    assert state == "charger_connected_sleep"
+    assert payload["soc"] == 70


### PR DESCRIPTION
## Summary
- add `pycanze.state` with SID constants, state detection, and sentinel filtering
- update MQTT poller to use new helper module
- test ready, charging, and sleep state handling with `ReplayClient`

## Testing
- `PYTHONPATH=PyCanZE pytest PyCanZE/tests/test_state.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba92106a8c8330b717f8e7f744fc7f