### PR TITLE
Document read-only diagnostic policy

### DIFF
--- a/PyCanZE/AGENTS.md
+++ b/PyCanZE/AGENTS.md
@@ -16,6 +16,14 @@ values over MQTT. A GUI similar to the original app may be built later.
 
 Contributions are welcome as this module is under active development.
 
+## Non-modifying policy
+
+PyCanZE tooling is strictly read-only. UDS services and ELM327 sequences in
+this directory must not issue write or actuation commands to any ECU. Future
+contributions must preserve this behaviour. If write access is ever explored,
+it needs to live behind explicit safeguards, require whitelists, and undergo
+careful review before enabling any modification on a vehicle.
+
 ## Handling vehicle states and sentinel values (2025-09-01)
 
 When agents/pollers consume PyCanZE, decide what to read/publish based on vehicle state. Some EVC/LBC values are unavailable or placeholders while the car sleeps, especially with the charger plugged but inactive.

--- a/PyCanZE/README.md
+++ b/PyCanZE/README.md
@@ -19,6 +19,13 @@ app's AT initialisation sequence and offers tuning knobs for flow-control and
 timing. An optional *wide CF fallback* widens receive filters and enables
 ``ATH1`` when LBC 0x21 pages miss consecutive frames.
 
+## Non-modifying policy
+
+All PyCanZE libraries and tools operate in a read-only manner. UDS services or
+other commands that could alter vehicle state are intentionally excluded. Any
+future write capability would need explicit safety mechanisms and review before
+being enabled.
+
 ## Build
 
 From this directory install the package with `pip`::

--- a/PyCanZE/pycanze/uds.py
+++ b/PyCanZE/pycanze/uds.py
@@ -6,7 +6,10 @@ it is used to manage the underlying connection; otherwise a small set of
 socket helpers derived from ``Testing/zoe_arrival_poller.py`` is employed.
 The client can query diagnostic data identifiers (DIDs) defined in the CanZE
 database and decode the returned payload using the field's bit positions,
-resolution and offset.
+resolution and offset.  It is intentionally limited to read-only diagnostics;
+write or actuation services (e.g. UDS 0x2E/0x31) are deliberately not
+implemented.  Any future write support must be gated behind explicit
+whitelists and safety checks.
 
 The default initialisation mirrors the Android driver's AT sequence::
 
@@ -42,8 +45,14 @@ class UDSClient:
     """Simple UDS client for querying diagnostic fields.
 
     Parameters mirror those used in the poller script. By default the CanZE
-    database is loaded so fields can be looked up by SID.
-    """
+    database is loaded so fields can be looked up by SID. The client only
+    issues read-oriented UDS services (0x21/0x22 along with session control and
+    tester-present keep-alives)."""
+
+    # Future write support, if ever implemented, should live in dedicated
+    # helpers (e.g. ``write_by_id``) that validate identifiers against a
+    # whitelist and require explicit user confirmation or safeguards before
+    # sending any UDS commands that could alter ECU state.
 
     def __init__(
         self,

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ The website can be found at http://canze.fisch.lu
 We strongly urge you to report bugs, issues and requests here on github using the issue system. You have to have a github account for that, but it offloads the team from an awful lot of administrative tasks, wasting valuable time that would better be spent on more productive work. You can report in English (preferred, and really, we don't mind language errors, NONE of the team members are native speakers!), German, French, Portuguese, Dutch and Danish, as long as you don't mind us answering in English, to keep things coordinated.
 
 
+# Non-modifying only
+
+CanZE and the companion PyCanZE tools are intended for passive, read-only
+diagnostics. Write or actuation commands over OBD/UDS are intentionally not
+supported and must not be added without explicit review and robust safety
+mechanisms.
+
 # Informal warning
 
 Before you download and use this software consider the following:


### PR DESCRIPTION
## Summary
- clarify PyCanZE is read-only and forbid write/actuation commands
- add non-modifying policy sections in project and PyCanZE docs
- note future write helpers must include safety gating

## Testing
- `pytest PyCanZE/tests`

------
https://chatgpt.com/codex/tasks/task_e_68baa37ad8308330ae50ed83296f2a60