### PR TITLE
Add configuration file support for MQTT poller

### DIFF
--- a/PyCanZE/README.md
+++ b/PyCanZE/README.md
@@ -62,6 +62,25 @@ payload before publishing, supply a CSV or SQLite target::
     python -m pycanze.mqtt_poller --mqtt-host 192.168.1.10 \
         --log-csv metrics.csv --log-rotate 1024
 
+Settings can also be supplied in a YAML or JSON file via ``--config``::
+
+    # mqtt.yml
+    interval: 60
+    mqtt_host: broker.local
+    mqtt_topic: canze/zoe
+    fields:
+      - 7ec.24.622002  # SOC
+      - 7ec.24.623206  # SOH
+      - 7ec.24.623203  # HV voltage
+      - 7ec.24.623200  # odometer
+    log_csv: metrics.csv
+
+Then run::
+
+    python -m pycanze.mqtt_poller --config mqtt.yml
+
+Command-line options override values from the configuration file.
+
 For standalone logging of arbitrary fields use the helper in `tools/`::
 
     python PyCanZE/tools/logger.py --fields 7ec.24.622002 7ec.24.623206 \

--- a/PyCanZE/pycanze/config.py
+++ b/PyCanZE/pycanze/config.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+try:
+    import yaml
+except Exception:  # pragma: no cover
+    yaml = None  # type: ignore
+
+
+def load_config(path: Optional[Path], overrides: Dict[str, Any]) -> Dict[str, Any]:
+    """Load a YAML/JSON config file and merge CLI overrides.
+
+    Parameters
+    ----------
+    path:
+        Optional path to a configuration file. When ``None`` no file is read.
+    overrides:
+        Mapping of CLI-provided values which should take precedence over the
+        file contents. Entries with ``None`` values are ignored.
+    """
+
+    cfg: Dict[str, Any] = {}
+    if path:
+        text = path.read_text()
+        if path.suffix.lower() in {".yaml", ".yml"}:
+            if yaml is None:  # pragma: no cover - import guard
+                raise RuntimeError("pyyaml is required for YAML configuration files")
+            cfg = yaml.safe_load(text) or {}
+        else:
+            cfg = json.loads(text)
+        # Resolve relative log paths against the config location
+        for key in ("log_csv", "log_sqlite"):
+            if key in cfg and cfg[key] is not None:
+                p = Path(cfg[key])
+                if not p.is_absolute():
+                    p = path.parent / p
+                cfg[key] = p
+    for k, v in overrides.items():
+        if v is not None:
+            cfg[k] = v
+    return cfg

--- a/PyCanZE/pycanze/mqtt_poller.py
+++ b/PyCanZE/pycanze/mqtt_poller.py
@@ -14,6 +14,7 @@ from typing import Optional
 import paho.mqtt.client as mqtt
 
 from pycanze import UDSClient  # type: ignore
+from pycanze.config import load_config  # type: ignore
 from pycanze.parser import load_fields  # type: ignore
 from pycanze.state import POLL_SIDS, build_payload, detect_state
 
@@ -38,6 +39,7 @@ def _safe_read(client: UDSClient, sid: str) -> Optional[float]:
 
 def parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Poll EVC fields and publish over MQTT")
+    p.add_argument("--config", type=Path, help="YAML/JSON configuration file")
     p.add_argument("--host", default=os.environ.get("PYCANZE_HOST", "192.168.2.21"))
     p.add_argument("--port", type=int, default=int(os.environ.get("PYCANZE_PORT", "35000")))
     p.add_argument("--mqtt-host", default=os.environ.get("MQTT_HOST", "localhost"))
@@ -45,6 +47,7 @@ def parse_args() -> argparse.Namespace:
     p.add_argument("--mqtt-topic", default=os.environ.get("MQTT_TOPIC", "canze/metrics"))
     p.add_argument("--vehicle", default=os.environ.get("PYCANZE_VEHICLE"))
     p.add_argument("--interval", type=int, default=300, help="Polling interval in seconds")
+    p.add_argument("--fields", nargs="+", help="Field identifiers to poll")
     p.add_argument("--log-csv", type=Path, help="Optional CSV log file")
     p.add_argument("--log-sqlite", type=Path, help="Optional SQLite log database")
     p.add_argument(
@@ -52,13 +55,23 @@ def parse_args() -> argparse.Namespace:
         type=int,
         help="Rotate logs when files exceed this size in kB",
     )
-    return p.parse_args()
+    args = p.parse_args()
+    overrides = {
+        k: v
+        for k, v in vars(args).items()
+        if k != "config" and v != p.get_default(k)
+    }
+    cfg = load_config(args.config, overrides)
+    for k, v in cfg.items():
+        setattr(args, k, v)
+    return args
 
 
 def main() -> None:
     args = parse_args()
     fields = load_fields(vehicle=args.vehicle)[0] if args.vehicle else load_fields()[0]
     client = UDSClient(args.host, port=args.port, fields=fields)
+    poll_sids = args.fields or list(POLL_SIDS)
     mqtt_client = mqtt.Client()
     mqtt_client.connect(args.mqtt_host, args.mqtt_port)
     mqtt_client.loop_start()
@@ -70,7 +83,7 @@ def main() -> None:
 
     try:
         while True:
-            vals = {sid: _safe_read(client, sid) for sid in POLL_SIDS}
+            vals = {sid: _safe_read(client, sid) for sid in poll_sids}
             state = detect_state(vals)
             payload = build_payload(vals, state)
             payload["timestamp"] = time.strftime("%Y-%m-%dT%H:%M:%S")

--- a/PyCanZE/tests/test_mqtt_poller_args.py
+++ b/PyCanZE/tests/test_mqtt_poller_args.py
@@ -1,5 +1,10 @@
 import sys
 import types
+import json
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency
+    yaml = None
 
 # Stub paho.mqtt.client before importing mqtt_poller
 mqtt_client_stub = types.SimpleNamespace(Client=lambda *args, **kwargs: None)
@@ -74,9 +79,10 @@ def test_cli_overrides_env(monkeypatch, tmp_path):
 
 
 def test_config_file(monkeypatch, tmp_path):
-    cfg = tmp_path / "cfg.yaml"
-    cfg.write_text(
-        """
+    cfg = tmp_path / ("cfg.yaml" if yaml else "cfg.json")
+    if yaml:
+        cfg.write_text(
+            """
 interval: 10
 mqtt_host: cfg.example
 mqtt_topic: cfg/topic
@@ -85,7 +91,19 @@ fields:
   - b
 log_csv: metrics.csv
 """
-    )
+        )
+    else:
+        cfg.write_text(
+            json.dumps(
+                {
+                    "interval": 10,
+                    "mqtt_host": "cfg.example",
+                    "mqtt_topic": "cfg/topic",
+                    "fields": ["a", "b"],
+                    "log_csv": "metrics.csv",
+                }
+            )
+        )
     monkeypatch.setattr(sys, "argv", ["mqtt_poller", "--config", str(cfg)])
     args = mqtt_poller.parse_args()
     assert args.interval == 10

--- a/PyCanZE/tests/test_mqtt_poller_args.py
+++ b/PyCanZE/tests/test_mqtt_poller_args.py
@@ -71,3 +71,30 @@ def test_cli_overrides_env(monkeypatch, tmp_path):
     assert args.log_csv == csv
     assert args.log_sqlite == db
     assert args.log_rotate == 99
+
+
+def test_config_file(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.yaml"
+    cfg.write_text(
+        """
+interval: 10
+mqtt_host: cfg.example
+mqtt_topic: cfg/topic
+fields:
+  - a
+  - b
+log_csv: metrics.csv
+"""
+    )
+    monkeypatch.setattr(sys, "argv", ["mqtt_poller", "--config", str(cfg)])
+    args = mqtt_poller.parse_args()
+    assert args.interval == 10
+    assert args.mqtt_host == "cfg.example"
+    assert args.mqtt_topic == "cfg/topic"
+    assert args.fields == ["a", "b"]
+    assert args.log_csv == cfg.parent / "metrics.csv"
+    monkeypatch.setattr(
+        sys, "argv", ["mqtt_poller", "--config", str(cfg), "--interval", "20"]
+    )
+    args = mqtt_poller.parse_args()
+    assert args.interval == 20


### PR DESCRIPTION
## Summary
- allow loading YAML/JSON configuration files for mqtt_poller via `--config`
- add `pycanze.config.load_config` helper to parse config files and merge CLI options
- document configuration file usage with example in README

## Testing
- `pytest PyCanZE/tests`


------
https://chatgpt.com/codex/tasks/task_e_68baacd57e7c833085eed6ed6cb2c4d0